### PR TITLE
Fix installing ubuntu-sdk-libs:armhf

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -157,9 +157,9 @@ Architecture: any
 Section: python
 Multi-Arch: allowed
 Depends: lsb-release,
-         python3-distro-info,
-         python3-psutil,
-         python3-xdg,
+         python3-distro-info:any,
+         python3-psutil:any,
+         python3-xdg:any,
          xdg-user-dirs,
          ${misc:Depends},
          ${python3:Depends}

--- a/debian/control
+++ b/debian/control
@@ -131,7 +131,6 @@ Description: d-bus service for managing libertine containers
 
 Package: liblibertine1
 Architecture: any
-Multi-Arch: same
 Depends: libertined,
          ${misc:Depends},
          ${shlibs:Depends}
@@ -144,7 +143,6 @@ Description: runtime for running deb-packaged X11 apps on Ubuntu Personal
 Package: liblibertine-dev
 Section: libdevel
 Architecture: any
-Multi-Arch: same
 Depends: liblibertine1 (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}

--- a/debian/control
+++ b/debian/control
@@ -155,11 +155,11 @@ Description: developer files for the Libertine application sandbox
 Package: python3-libertine
 Architecture: any
 Section: python
-Multi-Arch: allowed
+Multi-Arch: foreign
 Depends: lsb-release,
-         python3-distro-info:any,
-         python3-psutil:any,
-         python3-xdg:any,
+         python3-distro-info,
+         python3-psutil,
+         python3-xdg,
          xdg-user-dirs,
          ${misc:Depends},
          ${python3:Depends}

--- a/debian/control
+++ b/debian/control
@@ -112,8 +112,8 @@ Description: helper apps for using and interacting with Xmir
  Xmir and allowing copy and paste.
 
 Package: libertined
-Architecture: any
-Multi-Arch: same
+Architecture: all
+Multi-Arch: foreign
 Depends: procps,
          python3-libertine,
          python3-apt,
@@ -153,7 +153,7 @@ Description: developer files for the Libertine application sandbox
  the Ubuntu Personal sandbox for legacy Deb-packaged X11 applicatons.
 
 Package: python3-libertine
-Architecture: any
+Architecture: all
 Section: python
 Multi-Arch: foreign
 Depends: lsb-release,


### PR DESCRIPTION
This fixes trying to install ubuntu-sdk-libs:armhf on a amd64 machine, needed for clickable to use the sdk metapackage.


Please squash. 