### PR TITLE
Package name sanitisation

### DIFF
--- a/qml/common/ContainerEditView.qml
+++ b/qml/common/ContainerEditView.qml
@@ -58,7 +58,7 @@ Page {
             TextField {
                 id: enterPackageInput
                 placeholderText: i18n.tr("Package name or Debian package path")
-                inputMethodHints: Qt.ImhNoAutoUppercase| Qt.ImhPreferLowercase | Qt.ImhNoPredictiveText
+                inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase | Qt.ImhNoPredictiveText
                 onAccepted: okButton.clicked()
             }
 

--- a/qml/common/ContainerEditView.qml
+++ b/qml/common/ContainerEditView.qml
@@ -58,6 +58,7 @@ Page {
             TextField {
                 id: enterPackageInput
                 placeholderText: i18n.tr("Package name or Debian package path")
+                inputMethodHints: Qt.ImhNoAutoUppercase| Qt.ImhPreferLowercase | Qt.ImhNoPredictiveText
                 onAccepted: okButton.clicked()
             }
 


### PR DESCRIPTION
Added inputMethodHints when inputting package name to prefer lowercase, not add auto capitalisation and not use predictive text.
Should hopefully solve https://github.com/ubports/ubuntu-touch/issues/753
https://api-docs.ubports.com/sdk/apps/qml/QtQuick/TextEdit.html?highlight=textedit#sdk-qtquick-textedit-inputmethodhints
**NB - I haven't tested this - looking for discussion / feedback for now.**