### PR TITLE
Add Upstart job to remove Libertine scope click

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -4,7 +4,7 @@ install(FILES libertine-manager-app.desktop
         DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
 install(FILES libertine_64.png libertine-lxc.conf
   DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME})
-install(FILES libertine-xmir.conf
+install(FILES libertine-xmir.conf replace-libertine-scope.conf
         DESTINATION ${CMAKE_INSTALL_DATADIR}/upstart/sessions)
 install(FILES libertine-lxc-sudo libertine-lxd-sudo
         DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/sudoers.d)

--- a/data/replace-libertine-scope.conf
+++ b/data/replace-libertine-scope.conf
@@ -1,0 +1,19 @@
+description "Remove Libertine scope click"
+author "Dalton Durst <dalton@ubports.com>"
+
+# This job removes the Libertine click. This effectively replaces the scope
+# since it is now included in the image.
+
+start on starting unity8
+
+script
+    echo ""
+    if CLICK=`click info libertine-scope.ubuntu`; then
+        GET_VERSION="import json,sys; json_doc=json.loads(sys.stdin.read()); print(json_doc['version'])"
+        echo "Replacing Libertine scope"
+        LIBERTINE_SCOPE_VERSION=`echo $CLICK | python3 -c "$GET_VERSION"`
+        pkcon remove "libertine-scope.ubuntu;$LIBERTINE_SCOPE_VERSION;all;local:click"
+    else
+        echo "Scope click not installed, no need to replace."
+    fi
+end script


### PR DESCRIPTION
The unity8-dash uses a scope installed from a click before it will use
one from a deb whether or not the deb version is newer. Unfortunately,
users who have installed the Libertine scope while it was a click will
be stuck with it when they upgrade to 16.04. This commit adds an Upstart
job which checks if the libertine-scope.ubuntu click is installed, then
removes it if it is.

Fixes ubports/ubuntu-touch#906