### PR TITLE
Revert "Flatten surfaces by default."

### DIFF
--- a/tools/libertine-xmir
+++ b/tools/libertine-xmir
@@ -16,4 +16,4 @@
 
 
 # Add and/or remove Xmir options here
-exec Xmir -rootless -flatten $@
+exec Xmir -rootless $@


### PR DESCRIPTION
It seems like the problem that make flattening required is now fixed in
Unity8. Also, -flatten seems to be broken recently. It seems to cause
color inversion [1], and even cause LibreOffice to fail to launch.

[1] https://github.com/ubports/mir/pull/27#issuecomment-602802048

This reverts commit db15b606ff607e85306028a7a5c67bb8f8c978f0.