### PR TITLE
HostInfo: Force use of chroot mode

### DIFF
--- a/python/libertine/HostInfo.py
+++ b/python/libertine/HostInfo.py
@@ -25,12 +25,7 @@ from libertine import utils
 class HostInfo(object):
 
     def select_container_type_by_kernel(self):
-        if self.has_lxd_support():
-            return "lxd"
-        elif self.has_lxc_support():
-            return "lxc"
-        else:
-            return "chroot"
+        return "chroot"
 
     def has_lxc_support(self):
         kernel_release = platform.release().split('.')


### PR DESCRIPTION
On Ubuntu Touch we don't ship backends other than the chroot one.
Additionally, the other backends are not tested anyways, so force
the use of the chroot backend on all kernel versions.

This enables Libertine on the Sony Xperia X.