### PR TITLE
Re-introduce "Flatten surfaces by default."

### DIFF
--- a/tools/libertine-xmir
+++ b/tools/libertine-xmir
@@ -16,4 +16,4 @@
 
 
 # Add and/or remove Xmir options here
-exec Xmir -rootless $@
+exec Xmir -rootless -flatten $@


### PR DESCRIPTION
Seems like removing `-flatten` causes a problem with some poorly-
behaving apps. For example, Geany will create a bogus window of type
"normal" for every charactor typed via OSK (I guess it's supposed to
create only single of them, but perhaps Geany closes that window if it
loses focus from the main window).

To prevent regression from OTA-11, I decided to re-introduce `-flatten`.
With this, we're still regressing from color channel swap issue in
LXTerminal. But that's less severe, and probably easier to fix.

This reverts commit 8fc662cd6dc2d58e2eb2ce347b96d63d2fc97c53.