### PR TITLE
remove makedev as setting it up failed

### DIFF
--- a/python/libertine/ChrootContainer.py
+++ b/python/libertine/ChrootContainer.py
@@ -83,6 +83,7 @@ class LibertineChroot(BaseContainer):
         utils.get_logger().info(utils._("Fixing chroot symlinks..."))
         os.remove(os.path.join(self.root_path, 'dev'))
         os.remove(os.path.join(self.root_path, 'proc'))
+        self.run_in_container('apt remove -y makedev')
 
         with open(os.path.join(self.root_path, 'usr', 'sbin', 'policy-rc.d'), 'w+') as fd:
             fd.write("#!/bin/sh\n\n")


### PR DESCRIPTION
fix ubports/ubuntu-touch#1305

while setting up makedev, it tries to access files like /proc/1/environ and fails with permission denied. And so It fails to create the container